### PR TITLE
Adding a constructor to CacheableBitmapDrawable.java to let it implement the default (non deprecated) constructor with Bitmap parameter.

### DIFF
--- a/library/src/uk/co/senab/bitmapcache/CacheableBitmapDrawable.java
+++ b/library/src/uk/co/senab/bitmapcache/CacheableBitmapDrawable.java
@@ -26,9 +26,9 @@ public class CacheableBitmapDrawable extends BitmapDrawable {
 	static final String LOG_TAG = "CacheableBitmapDrawable";
 
     // URL Associated with this Bitmap
-	private final String mUrl;
+	private String mUrl;
 
-    private final BitmapLruCache.RecyclePolicy mRecyclePolicy;
+    private BitmapLruCache.RecyclePolicy mRecyclePolicy;
 
 	// Number of Views currently displaying bitmap
 	private int mDisplayingCount;
@@ -45,10 +45,19 @@ public class CacheableBitmapDrawable extends BitmapDrawable {
 	// Handler which may be used later
 	private static final Handler sHandler = new Handler(Looper.getMainLooper());
 
+
 	@SuppressWarnings("deprecation")
 	CacheableBitmapDrawable(String url, Bitmap bitmap, BitmapLruCache.RecyclePolicy recyclePolicy) {
 		super(bitmap);
+		init(url, recyclePolicy);
+	}
 
+	CacheableBitmapDrawable(Resources resources, String url, Bitmap bitmap, BitmapLruCache.RecyclePolicy recyclePolicy) {
+		super(resources, bitmap);
+		init(url, recyclePolicy);
+	}
+
+	private void init(String url, RecyclePolicy recyclePolicy) {
 		mUrl = url;
         mRecyclePolicy = recyclePolicy;
 		mDisplayingCount = 0;


### PR DESCRIPTION
This constructor is needed because the only one implemented for now is based on a deprecated one. The current constructor does not handle the screen/bitmap density scaling (Resources parameter). That can cause differences on bitmap rendering for this drawable.

Side effect, by using an init method to initialize the variables, I had to remove the final attribute to mUrl and mRecyclePolicy.
