### PR TITLE
Throw an exception when setImageBitmap is used on CacheableImageView

### DIFF
--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <uses-sdk android:minSdkVersion="4" />
 
-    <application android:label="@string/app_name" >
+    <application android:label="Android-BitmapCache" >
     </application>
 
 </manifest>

--- a/library/res/values/strings.xml
+++ b/library/res/values/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="app_name">Android-BitmapMemoryCache</string>
-</resources>

--- a/library/src/uk/co/senab/bitmapcache/CacheableImageView.java
+++ b/library/src/uk/co/senab/bitmapcache/CacheableImageView.java
@@ -16,6 +16,7 @@
 package uk.co.senab.bitmapcache;
 
 import android.content.Context;
+import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.util.AttributeSet;
@@ -42,7 +43,12 @@ public class CacheableImageView extends ImageView {
     public CacheableImageView(Context context, AttributeSet attrs) {
         super(context, attrs);
     }
-
+    
+    @Override
+    public void setImageBitmap(Bitmap bm) {
+    	throw new IllegalArgumentException("Do not use setImageBitmap on CacheableImageView otherwise the content is not cached");
+    }
+    
     @Override
     public void setImageDrawable(Drawable drawable) {
         final Drawable previousDrawable = getDrawable();


### PR DESCRIPTION
Since the Bitmap won't be cached that's a bad use of the cache specific widget
