### PR TITLE
Fix import DiskLruCache for latest version

### DIFF
--- a/library/src/uk/co/senab/bitmapcache/BitmapLruCache.java
+++ b/library/src/uk/co/senab/bitmapcache/BitmapLruCache.java
@@ -16,7 +16,7 @@
 
 package uk.co.senab.bitmapcache;
 
-import com.jakewharton.DiskLruCache;
+import com.jakewharton.disklrucache.DiskLruCache;
 
 import android.content.Context;
 import android.content.res.Resources;


### PR DESCRIPTION
"Could not find class 'com.jakewharton.DiskLruCache' "

Latest DiskLruCache has change its path in version 2.0.1.

This commit fixed the path problem.

Signed-off-by: Terrence Lee kill889@gmail.com
